### PR TITLE
Add images to output shifter, clean up text

### DIFF
--- a/content/devices/input-shift-register/_index.md
+++ b/content/devices/input-shift-register/_index.md
@@ -4,13 +4,13 @@ description: How to use input shift registers with MobiFlight
 next: devices/input-shift-register/wiring/
 ---
 
+When building panels, you may encounter situations where you have more buttons for input than available pins on your board. The solution is to use an input shift register like the [74HC165](https://www.ti.com/product/SN74HC165). This allows you to read input from eight buttons while only using three pins on the board.
+
 {{< cards >}}
 {{< card link="led" title="Input shift registers" image="card-images/devices/input-shift-register.png" >}}
 {{</ cards >}}
 
-When building panels, you may encounter situations where you have more buttons for input than available pins on your board. The solution is to use an input shift register like the [74HC165](https://www.ti.com/product/SN74HC165). This allows you to read input from eight buttons while only using three pins on the board.
-
-MobiFlight supports up to 32 bits of shift registers in a chain (typically four eight-bit chips), and up to six chains of input shifters can be connected to a single board.
+MobiFlight supports up to 32 bits of shift registers in a chain (typically four 8-bit chips), and up to six chains of input shifters can be connected to a single board.
 
 ## Popular options
 

--- a/content/devices/output-shift-register/_index.md
+++ b/content/devices/output-shift-register/_index.md
@@ -6,6 +6,13 @@ next: devices/output-shift-register/wiring
 
 LEDs are the most common output device when building panels, and it is often the case where the number of LEDs exceed the number of output pins or current available on a board. Output shift registers, in particular LED driver chips, solve this issue. They provide individual control of many LEDs using only three pins on a board. The brightness of all connected LEDs can be controlled by using a fourth board pin.
 
+{{< cards >}}
+{{< card title="74HC595" subtitle="Basic output shift register" image="card-images/devices/output-shift-register-74hc595.png" >}}
+{{< card title="DM13A" subtitle="LED driver for 16 LEDs" image="card-images/devices/output-shift-register-dm13a.png" >}}
+{{< /cards >}}
+
+MobiFlight supports up to 32 bits of shift registers in a chain (typically four 8-bit or two 16-bit chips), and up to six chains of output shifters can be connected to a single board.
+
 ## Popular options
 
 There are several output shift registers commonly used in panel builds. One is a basic shift register, the rest are specifically designed to manage multiple LEDs.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated input shift register documentation with clearer introduction about 74HC165 shift register
  - Enhanced output shift register documentation with:
    - Added visual cards for 74HC595 and DM13A shift register models
    - Clarified MobiFlight's support for up to 32 bits of shift registers in a chain

<!-- end of auto-generated comment: release notes by coderabbit.ai -->