### PR TITLE
Add an explicit warning that D0 and D1 are not usable on Mega, Uno, Nano

### DIFF
--- a/content/boards/arduino-mega-2560/index.md
+++ b/content/boards/arduino-mega-2560/index.md
@@ -42,7 +42,7 @@ While it has historically been a popular board for MobiFlight projects, the newe
 {{< pinout >}}
 
 > [!NOTE]
-> Pins D0 and D1 are not available for use.
+> Pins D0 and D1 are not available for use as they are reserved for USB serial communication.
 
 ## Additional resources
 

--- a/content/boards/arduino-mega-2560/index.md
+++ b/content/boards/arduino-mega-2560/index.md
@@ -42,7 +42,7 @@ While it has historically been a popular board for MobiFlight projects, the newe
 {{< pinout >}}
 
 > [!NOTE]
-> Pins D0 and D1 are not available for use as they are reserved for USB serial communication.
+> Pins D0 and D1 are not available for use, as they are reserved for USB serial communication.
 
 ## Additional resources
 

--- a/content/boards/arduino-mega-2560/index.md
+++ b/content/boards/arduino-mega-2560/index.md
@@ -41,6 +41,9 @@ While it has historically been a popular board for MobiFlight projects, the newe
 
 {{< pinout >}}
 
+> [!NOTE]
+> Pins D0 and D1 are not available for use.
+
 ## Additional resources
 
 - [Official technical documentation](https://docs.arduino.cc/hardware/mega-2560/)

--- a/content/boards/arduino-nano/index.md
+++ b/content/boards/arduino-nano/index.md
@@ -31,7 +31,7 @@ The Arduino Nano is a compact board that trades a smaller size for fewer IO pins
 {{< pinout >}}
 
 > [!NOTE]
-> Pins D0 and D1 are not available for use.
+> Pins D0 and D1 are not available for use as they are reserved for USB serial communication.
 
 ## Additional resources
 

--- a/content/boards/arduino-nano/index.md
+++ b/content/boards/arduino-nano/index.md
@@ -30,6 +30,9 @@ The Arduino Nano is a compact board that trades a smaller size for fewer IO pins
 
 {{< pinout >}}
 
+> [!NOTE]
+> Pins D0 and D1 are not available for use.
+
 ## Additional resources
 
 - [Buy from the MobiFlight shop and help support the project](https://shop.mobiflight.com/product/arduino-nano-usb-c)

--- a/content/boards/arduino-nano/index.md
+++ b/content/boards/arduino-nano/index.md
@@ -31,7 +31,7 @@ The Arduino Nano is a compact board that trades a smaller size for fewer IO pins
 {{< pinout >}}
 
 > [!NOTE]
-> Pins D0 and D1 are not available for use as they are reserved for USB serial communication.
+> Pins D0 and D1 are not available for use, as they are reserved for USB serial communication.
 
 ## Additional resources
 

--- a/content/boards/arduino-uno/index.md
+++ b/content/boards/arduino-uno/index.md
@@ -25,7 +25,7 @@ Unless you already own one, we recommend purchasing a different board, either th
 {{< pinout >}}
 
 > [!NOTE]
-> Pins D0 and D1 are not available for use as they are reserved for USB serial communication.
+> Pins D0 and D1 are not available for use, as they are reserved for USB serial communication.
 
 ## Additional resources
 

--- a/content/boards/arduino-uno/index.md
+++ b/content/boards/arduino-uno/index.md
@@ -25,7 +25,7 @@ Unless you already own one, we recommend purchasing a different board, either th
 {{< pinout >}}
 
 > [!NOTE]
-> Pins D0 and D1 are not available for use.
+> Pins D0 and D1 are not available for use as they are reserved for USB serial communication.
 
 ## Additional resources
 

--- a/content/boards/arduino-uno/index.md
+++ b/content/boards/arduino-uno/index.md
@@ -24,6 +24,9 @@ Unless you already own one, we recommend purchasing a different board, either th
 
 {{< pinout >}}
 
+> [!NOTE]
+> Pins D0 and D1 are not available for use.
+
 ## Additional resources
 
 - [Official technical documentation](https://docs.arduino.cc/hardware/uno-rev3/)

--- a/content/boards/mega-2560-pro-mini/index.md
+++ b/content/boards/mega-2560-pro-mini/index.md
@@ -25,7 +25,7 @@ but in a smaller package. If you need many IO pins, this is the recommended boar
 {{< pinout >}}
 
 > [!NOTE]
-> Pins D0 and D1 are not available for use.
+> Pins D0 and D1 are not available for use as they are reserved for USB serial communication.
 
 ## Additional resources
 

--- a/content/boards/mega-2560-pro-mini/index.md
+++ b/content/boards/mega-2560-pro-mini/index.md
@@ -25,7 +25,7 @@ but in a smaller package. If you need many IO pins, this is the recommended boar
 {{< pinout >}}
 
 > [!NOTE]
-> Pins D0 and D1 are not available for use as they are reserved for USB serial communication.
+> Pins D0 and D1 are not available for use, as they are reserved for USB serial communication.
 
 ## Additional resources
 

--- a/content/boards/mega-2560-pro-mini/index.md
+++ b/content/boards/mega-2560-pro-mini/index.md
@@ -24,6 +24,9 @@ but in a smaller package. If you need many IO pins, this is the recommended boar
 
 {{< pinout >}}
 
+> [!NOTE]
+> Pins D0 and D1 are not available for use.
+
 ## Additional resources
 
 - [Buy from the MobiFlight shop and help support the project](https://shop.mobiflight.com/product/arduino-mega-2560-pro-mini-usb-c)


### PR DESCRIPTION
Fixes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation for Arduino boards (Mega 2560, Nano, Uno, Mega 2560 Pro Mini) to clarify that pins D0 and D1 are not available for use as they are reserved for USB serial communication.
  - Added informative notes to enhance user understanding of board pin limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->