### PR TITLE
Remove Hugo language extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,6 @@
   "recommendations": [
     "esbenp.prettier-vscode",
     "tamasfe.even-better-toml",
-    "budparr.language-hugo-vscode",
     "yzhang.markdown-all-in-one",
     "streetsidesoftware.code-spell-checker",
     "jock.svg",


### PR DESCRIPTION
The extension doesn't work in devcontainers at all, and hasn't had any changes since 2022.