### PR TITLE
Note that Nano A6 and A7 are analog only, not digital

### DIFF
--- a/content/boards/recommended/arduino-nano/index.md
+++ b/content/boards/recommended/arduino-nano/index.md
@@ -33,6 +33,8 @@ The Arduino Nano is a compact board that trades a smaller size for fewer IO pins
 
 > [!NOTE]
 > Pins D0 and D1 are not available for use, as they are reserved for USB serial communication.
+>
+> Pins A6 and A7 are only available for analog input, they cannot be used as digital inputs.
 
 ## Additional resources
 


### PR DESCRIPTION
Fixes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Arduino Nano documentation to clarify the analog input limitations of pins A6 and A7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->