### PR TITLE
Add info about PWM brightness control to output shift registers

### DIFF
--- a/.vscode/markdown.code-snippets
+++ b/.vscode/markdown.code-snippets
@@ -33,5 +33,12 @@
 			"{{< card link=\"$1\" title=\"$2\" subtitle=\"$3\" image=\"card-images/devices/$4\" >}}"
 		],
 		"description": "Snippet for inserting a device card."
+	},
+	"Overline snippet": {
+		"prefix": "overline",
+		"body": [
+			"{{% overline %}}$1{{% /overline %}}"
+		],
+		"description": "Snippet for inserting overline shortcode."
 	}
 }

--- a/content/devices/output-shift-register/wiring/index.md
+++ b/content/devices/output-shift-register/wiring/index.md
@@ -32,6 +32,10 @@ Pay close attention to the orientation of the LEDs: the anode (long leg) should 
 {{< schematic image="dm13a.svg" title="Schematic for wiring a single DM13A chip." >}}
 
 The value of $R_{\text{ext}}$ determines the amount of current for the LEDs. A 5kΩ resistor results in approximately 12mA per LED, a good brightness level for most situations.
+
+> [!TIP]
+> Connecting pin 21, {{% overline %}}EN{{% /overline %}}, to a PWM pin on a board enables brightness control of the LEDs as a group from MobiFlight.
+
 {{< /tab >}}
 
 {{< tab >}}
@@ -40,6 +44,10 @@ Pay close attention to the orientation of the LEDs: the anode (long leg) should 
 {{< schematic image="tlc5917.svg" title="Schematic for wiring a single TLC5917 chip." >}}
 
 The value of $R_{\text{ext}}$ determines the amount of current for the LEDs. A 1.6kΩ resistor results in approximately 12mA per LED, a good brightness level for most situations.
+
+> [!TIP]
+> Connecting pin 13, {{% overline %}}OE{{% /overline %}}(ED2), to a PWM pin on a board enables brightness control of the LEDs as a group from MobiFlight.
+
 {{< /tab >}}
 
 {{< /tabs>}}

--- a/content/devices/output-shift-register/wiring/index.md
+++ b/content/devices/output-shift-register/wiring/index.md
@@ -12,7 +12,7 @@ The following components are required for an output shift register or LED driver
 - The output shift register or LED driver chip.
 - LEDs.
 - Assorted resistors.
-- 0.1uF capacitors.
+- 0.1µF capacitors.
 
 {{< tabs items="74HC595 DIP-16,DM13A DIP-24,TLC5917 DIP-16">}}
 

--- a/layouts/shortcodes/overline.html
+++ b/layouts/shortcodes/overline.html
@@ -1,0 +1,1 @@
+<span style="text-decoration:overline">{{ .Inner }}</span>


### PR DESCRIPTION
Fixes #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new VS Code snippet for inserting overline shortcode.
  - Enhanced device wiring documentation with LED brightness control tips for DM13A and TLC5917 chips.
  - Introduced a new HTML shortcode for applying overline text decoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->