### PR TITLE
Add 3D model links to boards

### DIFF
--- a/content/boards/recommended/arduino-nano/index.md
+++ b/content/boards/recommended/arduino-nano/index.md
@@ -39,5 +39,6 @@ The Arduino Nano is a compact board that trades a smaller size for fewer IO pins
 ## Additional resources
 
 - [Buy from the MobiFlight shop and help support the project](https://shop.mobiflight.com/product/arduino-nano-usb-c)
+- [3D model](https://grabcad.com/library/arduino-nano-ch430g-1)
 - [Official technical documentation](https://docs.arduino.cc/hardware/nano/)
 - [Pinout diagram (PDF)](pinout.pdf)

--- a/content/boards/recommended/pro-micro/index.md
+++ b/content/boards/recommended/pro-micro/index.md
@@ -49,6 +49,7 @@ The Pro Micro (16MHz) is a compact board that trades a smaller size for fewer IO
 ## Additional resources
 
 - [Buy from the MobiFlight shop and help support the project](https://shop.mobiflight.com/product/arduino-pro-micro-usb-c)
+- [3D model](https://grabcad.com/library/arduino-pro-micro-1)
 - [How to Revive a "Bricked" Pro Micro](https://learn.sparkfun.com/tutorials/pro-micro--fio-v3-hookup-guide/all#ts-revive)
 - [Official technical documentation](https://www.sparkfun.com/pro-micro-5v-16mhz.html#documentation)
 - [Pinout diagram (PDF)](pinout.pdf)

--- a/content/boards/recommended/raspberry-pi-pico/index.md
+++ b/content/boards/recommended/raspberry-pi-pico/index.md
@@ -47,5 +47,6 @@ The Raspberry Pi Pico 1 is a compact board with a moderate number of IO pins. It
 
 ## Additional resources
 
+- [3D model](https://datasheets.raspberrypi.com/pico/Pico-R3-step.zip)
 - [Official technical documentation](https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html#pico-1-technical-specification)
 - [Pinout diagram (PDF)](pinout.pdf)

--- a/content/boards/supported/arduino-mega-2560/index.md
+++ b/content/boards/supported/arduino-mega-2560/index.md
@@ -47,5 +47,6 @@ While it has historically been a popular board for MobiFlight projects, the newe
 
 ## Additional resources
 
+- [3D model](https://grabcad.com/library/arduino-mega-2560--1)
 - [Official technical documentation](https://docs.arduino.cc/hardware/mega-2560/)
 - [Pinout diagram (PDF)](pinout.pdf)

--- a/content/boards/supported/arduino-uno/index.md
+++ b/content/boards/supported/arduino-uno/index.md
@@ -44,5 +44,6 @@ Unless you already own one, we recommend purchasing a different board, either th
 
 ## Additional resources
 
+- [3D model](https://grabcad.com/library/arduino-uno-r3-ch340-1)
 - [Official technical documentation](https://docs.arduino.cc/hardware/uno-rev3/)
 - [Pinout diagram (PDF)](pinout.pdf)


### PR DESCRIPTION
Fixes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added 3D model links for multiple boards:
    - Arduino Nano (CH430G chip)
    - Pro Micro
    - Raspberry Pi Pico
    - Arduino Mega 2560 Rev3
    - Arduino Uno R3

These additions provide users with additional visual resources to better understand board designs and specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->