### PR TITLE
Add deployment documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
     ".gitignore": ".gitattributes, .hugoignore",
     "hugo.yaml": ".markdownlint.json, go.mod, go.sum, .coderabbit.yml, .prettierrc.json",
     "eslint.config.js": ".markdownlint.jsonc",
-    "README.md": "DEVELOPMENT.md"
+    "README.md": "DEVELOPMENT.md, DEPLOYMENT.md"
   },
   "files.associations": {
     "*.svg.html": "plaintext"
@@ -60,10 +60,12 @@
     "mfmc",
     "microcontroller",
     "Mobi",
+    "mobiflight",
     "Möbius",
     "mosfet",
     "MOSFETs",
     "MSFS",
+    "neilenns",
     "Nema",
     "Octavi",
     "ogimage",

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,51 @@
+# Deploying the documentation
+
+The documentation can be deployed to any hosting provider as a static website. To build the site run the following command:
+
+```bash
+hugo -b <baseUrl>
+```
+
+Where `<baseUrl>` is the base URL of the site. For example, the live site is deployed using this command:
+
+```bash
+hugo -b https://docs.mobiflight.com/
+```
+
+The static pages for deployment are placed in the `./public` folder after the build completes.
+
+## Deploying to CloudFlare Pages: Production
+
+The site is deployed to the CloudFlare Pages production environment with the following settings:
+
+| Setting              | Sub-setting           | Value                               |
+| -------------------- | --------------------- | ----------------------------------- |
+| Git repository       |                       | `neilenns-projects/mobiflight-docs` |
+| Build configuration  | Build command         | `hugo -b $CF_PAGES_URL`             |
+| Build configuration  | Output directory      | `public`                            |
+| Build configuration  | Root directory        | *leave empty*                       |
+| Build configuration  | Build comments        | Enabled                             |
+| Build cache          |                       | Disabled                            |
+| Branch control       | Production branch     | `main`                              |
+| Branch control       | Automatic deployments | Enabled                             |
+| Build watch paths    | Include paths         | `*`                                 |
+| Build system version |                       | `2`                                 |
+| Deploy hooks         |                       | *leave empty*                       |
+
+Use the following variables and secrets:
+
+| Type      | Name         | Value   |
+| --------- | ------------ | ------- |
+| Plaintext | HUGO_VERSION | 0.140.2 |
+
+Failing to set the `HUGO_VERSION` variable will result in the deployments failing.
+
+## Deploying to CloudFlare Pages: Preview
+
+CloudFlare Pages automatically deploys a preview version of the site for each pull request. The settings are identical to the production environment, with the following exceptions:
+
+| Setting        | Sub-setting    | Value                       |
+| -------------- | -------------- | --------------------------- |
+| Branch control | Preview branch | All non-production branches |
+
+Remember to set the `HUGO_VERSION` variable on the preview environment as well, otherwise the deployments will fail.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # MobiFlight Documentation
 
-Documentation website for MobiFlight, written in [Hugo](https://gohugo.io/) with the [Hextra theme](https://imfing.github.io/hextra/docs/getting-started/).
+Documentation website for MobiFlight, written in [Hugo](https://gohugo.io/) with the [Hextra theme](https://imfing.github.io/hextra/docs/getting-started/). This documentation is deployed using CloudFlare Pages to the [MobiFlight documentation site](https://docs.mobiflight.com/). See the [deployment guide](DEPLOYMENT.md) for information on how to deploy.
+
+## Editing the documentation
 
 The documentation is set up for editing using Visual Studio Code dev containers:
 
@@ -17,7 +19,7 @@ To view the documentation press `F5` and it will automatically build and open in
 
 ## Style guidelines
 
-## General conventions
+### General conventions
 
 - Filenames are in lowercase, spaces are replaced with hyphens (-).
 - All Markdown files must pass markdownlint.
@@ -56,14 +58,14 @@ To view the documentation press `F5` and it will automatically build and open in
 - Store in the `assets/card-images` folder.
 - Reference using the `{{% card %}}` shortcode, accessible using the VSCode `board` and `device` snippets.
 
-## Pinout diagrams
+### Pinout diagrams
 
 - Use `.svg` format for all pinout diagrams.
 - Process the files using [svgomg](https://svgomg.net/) with the default options plus `Prefer viewBox to width/height` enabled.
 - Store in the page bundle for the associated board and name the file `pinout.svg`.
 - Reference using the `{{< pinout >}}` shortcode, accessible using the VSCode snippet `pinout`.
 
-## Schematics
+### Schematics
 
 - Use `.svg` format for all schematics.
 - Prefer net labels over global labels.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the deployment guide with detailed instructions on hosting the site as a static website using Hugo and CloudFlare Pages, covering both production and preview setups.
  - Introduced a new section outlining the process for editing the documentation with a development container.
  - Reorganized content structure for enhanced clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->