### PR TITLE
Add X-Plane profiles link

### DIFF
--- a/content/joysticks/winwing/index.md
+++ b/content/joysticks/winwing/index.md
@@ -11,7 +11,9 @@ MobiFlight supports the WINWING FCU, MCDU, and PFP3N (buttons only).
 
 ## Using pre-made MobiFlight profiles
 
-Many MobiFlight profiles for WINWING devices are available on [flightsim.to](https://flightsim.to/discover/winwing). Take the following steps to use the pre-made profile:
+Many MobiFlight profiles for WINWING devices are available. See [flightsim.to](https://flightsim.to/discover/winwing) for Microsoft Flight Simulator profiles, and the [X-Plane forums](https://forums.x-plane.org/index.php?/search/&q=winwing&quick=1) for X-Plane profiles.
+
+Take the following steps to use the pre-made profile:
 
 {{% steps %}}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the profile sourcing details for WINWING devices, now specifying that pre-made profiles are available on flightsim.to for Microsoft Flight Simulator and on the X-Plane forums for X-Plane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->