### PR TITLE
Clarify when value fields exist

### DIFF
--- a/content/guides/modifying-values-with-ncalc/_index.md
+++ b/content/guides/modifying-values-with-ncalc/_index.md
@@ -5,7 +5,7 @@ description: How to use NCalc to modify values in MobiFlight.
 
 MobiFlight supports NCalc expressions to adjust values received from the simulator. Expressions can be used in:
 
-- Value fields for input configurations.
+- Input configurations that have value fields, most commonly **MobiFlight - Variable** configurations.
 - [Transform](/guides/modifiers/transform/) modifiers on output configurations.
 - Value fields in [compare](/guides/modifiers/compare/) modifiers on output configurations.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the guide to clarify that NCalc expressions are applicable in input configurations, with a focus on the common use case of variable configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->