### PR TITLE
Add a note about extraction location to Winwing pre-made profile guide

### DIFF
--- a/content/game-controllers/winwing/premade-profiles/index.md
+++ b/content/game-controllers/winwing/premade-profiles/index.md
@@ -17,6 +17,9 @@ Take the following steps to use the pre-made profile:
 
 Using **File Explorer**, select the downloaded zip file and click **Extract all** in the ribbon to extract the profile.
 
+> [!TIP]
+> Extract the profile to a location other than the Downloads folder. For example, extract to the **Documents\MobiFlight** folder.
+
 {{< screenshot image="file-explorer.png" title="Screenshot of the Windows File Explorer with a downloaded profile zip file selected and the Extract all button highlighted." >}}
 
 ### Open the profile in MobiFlight


### PR DESCRIPTION
Fixes #285

![image](https://github.com/user-attachments/assets/ab5c7bc4-0825-4a16-a164-8cb05c616dc6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guidance on extracting profile files, advising users to avoid the Downloads folder and instead use a dedicated location (e.g., Documents\MobiFlight) for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->