### PR TITLE
Fix the supported winwing device list

### DIFF
--- a/content/game-controllers/_index.md
+++ b/content/game-controllers/_index.md
@@ -21,3 +21,4 @@ For popular devices, MobiFlight displays friendly names during input and output 
 - [VKBsim flight simulation controllers](https://www.vkbcontrollers.com/)
 - [WinWing Flight Control Unit (FCU)](https://us.winwingsim.com/view/goods-details.html?id=550)
 - [WinWing EFIS Left display](https://us.winwingsim.com/view/goods-details.html?id=845) and [WinWing EFIS Right display](https://us.winwingsim.com/view/goods-details.html?id=865)
+- [WINWING MCDU](https://us.winwingsim.com/view/goods-details.html?id=945) and [WINWING PFP 3N](https://us.winwingsim.com/view/goods-details.html?id=965)

--- a/content/game-controllers/winwing/_index.md
+++ b/content/game-controllers/winwing/_index.md
@@ -7,7 +7,7 @@ next: /game-controllers/winwing/premade-profiles/
 weight: 50
 ---
 
-MobiFlight supports the WINWING WINWING FCU, EFIS, MCDU and PFP 3N.
+MobiFlight supports the WINWING FCU, EFIS, MCDU and PFP 3N.
 
 WINWING devices are automatically shown in the input and output configuration dialogs. They will not appear in the **Modules** tab of the **Settings** dialog as they are not [boards](/boards/).
 

--- a/content/game-controllers/winwing/_index.md
+++ b/content/game-controllers/winwing/_index.md
@@ -7,7 +7,7 @@ next: /game-controllers/winwing/premade-profiles/
 weight: 50
 ---
 
-MobiFlight supports the WINWING FCU and CDU devices.
+MobiFlight supports the WINWING WINWING FCU, EFIS, MCDU and PFP 3N.
 
 WINWING devices are automatically shown in the input and output configuration dialogs. They will not appear in the **Modules** tab of the **Settings** dialog as they are not [boards](/boards/).
 


### PR DESCRIPTION
Fixes #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Expanded the supported devices list by adding WINWING MCDU and WINWING PFP 3N with corresponding links.
	- Updated the device details to now include WINWING EFIS alongside the existing WINWING FCU and MCDU, enhancing the overall user information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->