### PR TITLE
Updated links on unsupported boards

### DIFF
--- a/content/boards/unsupported/esp32/index.md
+++ b/content/boards/unsupported/esp32/index.md
@@ -5,7 +5,7 @@ ogimage: card-images/boards/arduino-nano-esp32.png
 ---
 
 > [!IMPORTANT]
-> These boards are unsupported. Consider a [Raspberry Pi Pico 1](/boards/raspberry-pi-pico) instead.
+> These boards are unsupported. Consider a [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico) instead.
 
 While various boards with ESP32 chips are available as a pin-compatible replacement for other
 microcontroller boards, the different architecture of the ESP32 processor requires a firmware

--- a/content/boards/unsupported/raspberry-pi-pico-2/index.md
+++ b/content/boards/unsupported/raspberry-pi-pico-2/index.md
@@ -5,9 +5,9 @@ ogimage: card-images/boards/raspberry-pi-pico2.png
 ---
 
 > [!IMPORTANT]
-> This board is unsupported. Consider a [Raspberry Pi Pico 1](../../raspberry-pi-pico) instead.
+> This board is unsupported. Consider a [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico) instead.
 
-The Raspberry Pi Pico 2 is the successor to the popular [Raspberry Pi Pico 1](../../raspberry-pi-pico).
+The Raspberry Pi Pico 2 is the successor to the popular [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico).
 Like its predecessor, it is a compact board with a moderate number of IO pins, ideal for builds where
 space is at a premium. Unlike its predecessor, which uses the RP2040 chip, the Pico 2 uses the newer
 RP2350 microcontroller. Due to the relatively recent release of this component, small installed base


### PR DESCRIPTION
Fixes #311 - the unsupported boards were still linking to the unsubfoldered Pico 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated links to the Raspberry Pi Pico 1 board documentation to use the new recommended URL path in important notices and introductory descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->