### PR TITLE
Update docs with correct minimum Python version

### DIFF
--- a/content/guides/installing-python/_index.md
+++ b/content/guides/installing-python/_index.md
@@ -5,7 +5,7 @@ description: Installing Python for use with MobiFlight.
 
 Python is the primary scripting language used by MobiFlight to connect custom aircraft APIs to [WinWing CDUs](/game-controllers/winwing/winwing-cdu/). The following must be installed for MobiFlight to work with Python:
 
-- Python version `v3.10` or later.
+- Python version `v3.11` or later.
 - The `websockets`, `gql`, and `SimConnect` Python packages.
 
 ## Python installation instructions


### PR DESCRIPTION
See https://discord.com/channels/608690978081210392/1373207473774661703/1373207473774661703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the installation guide to specify Python 3.11 as the minimum required version for MobiFlight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->