### PR TITLE
Add CRJ and Headwind A339x to supported planes

### DIFF
--- a/content/game-controllers/winwing/winwing-cdu/_index.md
+++ b/content/game-controllers/winwing/winwing-cdu/_index.md
@@ -15,10 +15,12 @@ MobiFlight supports WINWING CDU devices with the MobiFlight 11 beta builds. All 
 | MSFS     | FlyByWire A32NX | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
 | MSFS     | FSLabs A321     | CPT                      |                                                                                                           |
 | MSFS     | iFly 737        | CPT or FO or CPT+FO      | CPT+FO untested so far                                                                                    |
-| MSFS     | Maddog X        | CPT or FO or CPT+FO      | CPT+FO untested so far                                                                                    |
+| MSFS     | Maddog X        | CPT or FO or CPT+FO      |                                                                                                           |
 | MSFS     | PMDG 737        | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
 | MSFS     | PMDG 777        | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
 | MSFS     | TFDi MD-11      | CPT or FO or CPT+FO      |                                                                                                           |
+| MSFS     | Headwind A339x  | CPT or FO                | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | Aerosoft CRJ    | CPT or FO or CPT+FO      |                                                                                                           |
 
 To get the beta build and install pre-requisites for CDU display support, take the following steps:
 

--- a/content/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/index.md
+++ b/content/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/index.md
@@ -8,7 +8,7 @@ weight: 50
 
 Certain aircraft require additional steps for the WINWING CDU display to work properly. See the section below for the necessary steps for each aircraft.
 
-{{% details title="FlyByWire A32NX" closed="true" %}}
+{{% details title="FlyByWire A32NX and Headwind A339x" closed="true" %}}
 
 The FlyByWire A32NX support requires FBW SimBridge.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated compatibility table to reflect tested support for WINWING CDU CPT+FO configuration with Maddog X.
  - Added compatibility information for Headwind A339x and Aerosoft CRJ aircraft.
  - Clarified that configuration instructions apply to both FlyByWire A32NX and Headwind A339x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->