### PR TITLE
Add command line parameter documentation

### DIFF
--- a/content/features/_index.md
+++ b/content/features/_index.md
@@ -10,6 +10,7 @@ cascade:
 {{< cards >}}
 
 {{< card link="/features/auto-load-config/" title="Auto-loading configurations" icon="information" >}}
+{{< card link="/features/command-line-parameters/" title="Command line parameters" icon="information" >}}
 {{< card link="/features/input-action-types/" title="Input action types" icon="information" >}}
 {{< card link="/features/modifiers/" title="Output value modifiers" icon="adjustments" >}}
 {{< card link="/features/output-variable-types/" title="Output variable types" icon="information" >}}

--- a/content/features/command-line-parameters/index.md
+++ b/content/features/command-line-parameters/index.md
@@ -7,10 +7,10 @@ MobiFlight supports the following command line parameters:
 
 | Parameter | Description                                                                                                               | Example                                                    |
 | --------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| autoRun   | Enables AutoRun mode.                                                                                                     | `MobiFlight-Connector.exe /autoRun`                        |
-| cfg       | Specifies the configuration file to open on startup. If not specified, MobiFlight opens the last used configuration file. | `MobiFlight-Connector.exe /cfg "C:\MobiFlight\config.mcc"` |
+| `autoRun` | Enables AutoRun mode.                                                                                                     | `MobiFlight-Connector.exe /autoRun`                        |
+| `cfg`     | Specifies the configuration file to open on startup. If not specified, MobiFlight opens the last used configuration file. | `MobiFlight-Connector.exe /cfg "C:\MobiFlight\config.mcc"` |
 
-You can combine both parameters to load a specific configuration file, and automatically have MobiFlight start "Run" mode as soon as the flight sim is detected, by combining the parameters:
+To load a specific configuration file and automatically start `Run` mode when the flight simulator is detected, combine the parameters:
 
 ```powershell
 MobiFlight-Connector.exe /cfg "C:\MobiFlight\myconfig.mcc" /autoRun


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added new documentation explaining supported command line parameters, including usage examples for `autoRun` and `cfg` options.
  - Introduced a new feature card for command line parameters on the features index page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->