### PR TITLE
Add Winwing PFP 7

### DIFF
--- a/content/game-controllers/winwing/_index.md
+++ b/content/game-controllers/winwing/_index.md
@@ -10,7 +10,7 @@ weight: 50
 <!-- Markdownlint doesn't know about consecutive GitHub tip blocks -->
 <!-- markdownlint-disable MD028-->
 
-MobiFlight supports the WINWING FCU, EFIS, MCDU and PFP 3N.
+MobiFlight supports the WINWING FCU, EFIS, MCDU, PFP 3N and PFP 7.
 
 The WINWING CDU requires the MobiFlight 11 beta, and its inputs work like any other [game controller input](/game-controllers/configuring-input/). The display portion of the CDU with MobiFlight requires additional configuration, and is only supported with specific aircraft. See the [WINWING CDU documentation](/game-controllers/winwing/winwing-cdu/) for more information.
 


### PR DESCRIPTION
Add Winwing PFP 7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to include support for the WINWING PFP 7 device alongside existing supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->