### PR TITLE
Add X-Plane CDU support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
     }
   },
   "cSpell.words": [
+    "Aerosoft",
     "Akai",
     "Anson",
     "ATIS",
@@ -69,6 +70,7 @@
     "KTCM",
     "KTIW",
     "KUAO",
+    "Liss",
     "localappdata",
     "Maddog",
     "MCDU",

--- a/content/game-controllers/winwing/winwing-cdu/_index.md
+++ b/content/game-controllers/winwing/winwing-cdu/_index.md
@@ -9,29 +9,28 @@ weight: 30
 
 MobiFlight supports WINWING CDU devices with the MobiFlight 11 beta builds. All buttons are automatically available as [game controller inputs](/game-controllers/configuring-input/); however, using the display for output requires additional setup and is only supported with the following aircraft:
 
-| Platform | Aircraft           | Supported configurations | Comment                                                                                                   |
-| -------- | ------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| MSFS     | Aerosoft CRJ       | CPT or FO or CPT+FO      |                                                                                                           |
-| MSFS     | Fenix A3xx         | CPT or FO or CPT+FO      |                                                                                                           |
-| MSFS     | FlyByWire A32NX    | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
-| MSFS     | FSLabs A321        | CPT                      |                                                                                                           |
-| MSFS     | Headwind A339x     | CPT or FO                | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
-| MSFS     | iFly 737           | CPT or FO or CPT+FO      | CPT+FO untested so far                                                                                    |
-| MSFS     | Maddog X           | CPT or FO or CPT+FO      |                                                                                                           |
-| MSFS     | PMDG 737           | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
-| MSFS     | PMDG 777           | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
-| MSFS     | TFDi MD-11         | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | FlightFactor 757   | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | FlightFactor 767   | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | FlightFactor 777v2 | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | Laminar 737        | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | LevelUp 737        | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | ToLiss A319        | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | ToLiss A320        | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | ToLiss A321        | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | ToLiss A330        | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | ToLiss A340        | CPT or FO or CPT+FO      |                                                                                                           |
-| X-Plane  | Zibo 737           | CPT or FO or CPT+FO      |                                                                                                           |
+| Platform | Aircraft           | Supported configurations                 | Comment                                                                                                   |
+| -------- | ------------------ | ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| MSFS     | Aerosoft CRJ       | CPT or FO or CPT+FO                      |                                                                                                           |
+| MSFS     | Fenix A3xx         | CPT or FO or CPT+FO                      |                                                                                                           |
+| MSFS     | FlyByWire A32NX    | CPT or FO or CPT+FO                      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | FSLabs A321        | CPT                                      |                                                                                                           |
+| MSFS     | Headwind A339x     | CPT or FO                                | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | iFly 737           | CPT or FO or CPT+FO                      | CPT+FO untested so far                                                                                    |
+| MSFS     | Maddog X           | CPT or FO or CPT+FO                      |                                                                                                           |
+| MSFS     | PMDG 737           | CPT or FO or CPT+FO                      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | PMDG 777           | CPT or FO or CPT+FO                      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | TFDi MD-11         | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | FlightFactor 757   | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | FlightFactor 767   | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | FlightFactor 777v2 | CPT or FO or Observer or CPT+FO+Observer |                                                                                                           |
+| X-Plane  | LevelUp 737        | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | ToLiss A319        | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | ToLiss A320        | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | ToLiss A321        | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | ToLiss A330        | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | ToLiss A340        | CPT or FO or CPT+FO                      |                                                                                                           |
+| X-Plane  | Zibo 737           | CPT or FO or CPT+FO                      |                                                                                                           |
 
 To get the beta build and install pre-requisites for CDU display support, take the following steps:
 

--- a/content/game-controllers/winwing/winwing-cdu/_index.md
+++ b/content/game-controllers/winwing/winwing-cdu/_index.md
@@ -9,18 +9,29 @@ weight: 30
 
 MobiFlight supports WINWING CDU devices with the MobiFlight 11 beta builds. All buttons are automatically available as [game controller inputs](/game-controllers/configuring-input/); however, using the display for output requires additional setup and is only supported with the following aircraft:
 
-| Platform | Aircraft        | Supported configurations | Comment                                                                                                   |
-| -------- | --------------- | ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| MSFS     | Fenix A3xx      | CPT or FO or CPT+FO      |                                                                                                           |
-| MSFS     | FlyByWire A32NX | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
-| MSFS     | FSLabs A321     | CPT                      |                                                                                                           |
-| MSFS     | iFly 737        | CPT or FO or CPT+FO      | CPT+FO untested so far                                                                                    |
-| MSFS     | Maddog X        | CPT or FO or CPT+FO      |                                                                                                           |
-| MSFS     | PMDG 737        | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
-| MSFS     | PMDG 777        | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
-| MSFS     | TFDi MD-11      | CPT or FO or CPT+FO      |                                                                                                           |
-| MSFS     | Headwind A339x  | CPT or FO                | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
-| MSFS     | Aerosoft CRJ    | CPT or FO or CPT+FO      |                                                                                                           |
+| Platform | Aircraft           | Supported configurations | Comment                                                                                                   |
+| -------- | ------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| MSFS     | Aerosoft CRJ       | CPT or FO or CPT+FO      |                                                                                                           |
+| MSFS     | Fenix A3xx         | CPT or FO or CPT+FO      |                                                                                                           |
+| MSFS     | FlyByWire A32NX    | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | FSLabs A321        | CPT                      |                                                                                                           |
+| MSFS     | Headwind A339x     | CPT or FO                | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | iFly 737           | CPT or FO or CPT+FO      | CPT+FO untested so far                                                                                    |
+| MSFS     | Maddog X           | CPT or FO or CPT+FO      |                                                                                                           |
+| MSFS     | PMDG 737           | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | PMDG 777           | CPT or FO or CPT+FO      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
+| MSFS     | TFDi MD-11         | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | FlightFactor 757   | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | FlightFactor 767   | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | FlightFactor 777v2 | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | Laminar 737        | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | LevelUp 737        | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | ToLiss A319        | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | ToLiss A320        | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | ToLiss A321        | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | ToLiss A330        | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | ToLiss A340        | CPT or FO or CPT+FO      |                                                                                                           |
+| X-Plane  | Zibo 737           | CPT or FO or CPT+FO      |                                                                                                           |
 
 To get the beta build and install pre-requisites for CDU display support, take the following steps:
 


### PR DESCRIPTION
Fixes #338 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and reorganized the list of supported aircraft for WINWING CDU display output, adding a new section for X-Plane aircraft and alphabetizing MSFS aircraft.
* **Chores**
  * Updated spell checker dictionary to recognize "Aerosoft" and "Liss" as valid words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->