### PR TITLE
Update workshop stl file links

### DIFF
--- a/content/guides/workshops/advanced/_index.md
+++ b/content/guides/workshops/advanced/_index.md
@@ -19,8 +19,8 @@ The following components are required for the project:
 | [LED push button](/devices/button-switch/)                                                  | 2        |
 | [Dual encoder with breakout board](https://shop.mobiflight.com/product/dual-encoder-bundle) | 1        |
 | Micro-switch PCB                                                                            | 1        |
-| XH-JST 3-pin wire                                                                           | 1        |
-| XH-JST 4-pin wire                                                                           | 3        |
+| JST XH 3-pin wire                                                                           | 1        |
+| JST XH 4-pin wire                                                                           | 3        |
 | M3x5mm screw                                                                                | 12       |
 
 ## 3D-printed enclosure parts
@@ -55,9 +55,9 @@ Use the [installing configuration guide](/guides/workshops/installing-configurat
 
 {{< screenshot image="micro-switch-assembly.png" title="Photo of the advanced project with the two micro-switches highlighted." >}}
 
-Insert the micro-switches into the lid and attach the PCB from behind with M3 screws. Plug in the XH-JST 3-pin cable, and pass it through the back of the case.
+Insert the micro-switches into the lid and attach the PCB from behind with M3 screws. Plug in the JST XH 3-pin cable, and pass it through the back of the case.
 
-The micro-switches are connected using XH-JST 3-pin cables. Connect the top switch to `SWITCH 1 (ON-ON)` on the breakout board.
+The micro-switches are connected using JST XH 3-pin cables. Connect the top switch to `SWITCH 1 (ON-ON)` on the breakout board.
 
 {{< screenshot image="micro-switch-connection.png" title="Photo of a prototype board with the connection for the micro-switches highlighted." >}}
 
@@ -65,9 +65,9 @@ The micro-switches are connected using XH-JST 3-pin cables. Connect the top swit
 
 {{< screenshot image="lcd-assembly.png" title="Photo of the advanced project with the LCD highlighted." >}}
 
-Assemble the LCD into the case lid with M3 screws. Connect the XH-JST 4-pin cable to the back of the LCD, making sure to connect the black wire to **GND**, then pass the wire through the back of the case.
+Assemble the LCD into the case lid with M3 screws. Connect the JST XH 4-pin cable to the back of the LCD, making sure to connect the black wire to **GND**, then pass the wire through the back of the case.
 
-The LCD is connected using a XH-JST 4-pin cable. Connect the display to `LCD 1` on the breakout board.
+The LCD is connected using a JST XH 4-pin cable. Connect the display to `LCD 1` on the breakout board.
 
 {{< screenshot image="lcd-connection.png" title="Photo of a prototype board with the LCD connection highlighted." >}}
 
@@ -77,7 +77,7 @@ The LCD is connected using a XH-JST 4-pin cable. Connect the display to `LCD 1` 
 
 Assemble the encoder into the case using M3 screws to attach the PCB to the back of the lid. Pass the cable through the hole in the back of the case, then close the lid. Bending the cable 90 degrees, close to the PCB, helps make everything fit.
 
-The encoder is connected using two XH-JST 4-pin cables. Connect the encoder PCB `INNER SHAFT` connector to `ENCODER 1`, and the `OUTER SHAFT` connector to `ENCODER 2`, on the breakout board.
+The encoder is connected using two JST XH 4-pin cables. Connect the encoder PCB `INNER SHAFT` connector to `ENCODER 1`, and the `OUTER SHAFT` connector to `ENCODER 2`, on the breakout board.
 
 {{< screenshot image="dual-encoder-connections.png" title="Photo of a prototype board with the dual encoder connections highlighted." >}}
 

--- a/content/guides/workshops/beginner/_index.md
+++ b/content/guides/workshops/beginner/_index.md
@@ -34,9 +34,9 @@ The following components are required for the project:
 | [Encoder with breakout board](https://shop.mobiflight.com/product/single-encoder-bundle)   | 1        |
 | [ON-ON switch](https://shop.mobiflight.com/product/switch-12mm-panel-mount)                | 2        |
 | MobiFlight switch breakout board                                                           | 1        |
-| XH-JST 2-pin wire {{< br >}} (soldered to push button)                                     | 4        |
-| XH-JST 3-pin wire                                                                          | 2        |
-| XH-JST 4-pin wire                                                                          | 1        |
+| JST XH 2-pin wire {{< br >}} (soldered to push button)                                     | 4        |
+| JST XH 3-pin wire                                                                          | 2        |
+| JST XH 4-pin wire                                                                          | 1        |
 | M3x5mm screw                                                                               | 8        |
 
 {{< /tab >}}
@@ -52,9 +52,9 @@ The following components are required for the project:
 | [Encoder with breakout board](https://shop.mobiflight.com/product/single-encoder-bundle)   | 1        |
 | [ON-ON switch](https://shop.mobiflight.com/product/switch-12mm-panel-mount)                | 2        |
 | MobiFlight switch breakout board                                                           | 1        |
-| XH-JST 2-pin wire                                                                          | 4        |
-| XH-JST 3-pin wire                                                                          | 2        |
-| XH-JST 4-pin wire                                                                          | 1        |
+| JST XH 2-pin wire                                                                          | 4        |
+| JST XH 3-pin wire                                                                          | 2        |
+| JST XH 4-pin wire                                                                          | 1        |
 | M3x5mm screw                                                                               | 12       |
 
 {{< /tab >}}
@@ -149,7 +149,7 @@ With all wires connected, push the lid into the case such that the labels on the
 
 Assemble the toggle switches into the case by screwing a nut halfway down the threads on each switch. Place both switches on the PCB, then use M3 screws to attach the PCB to the back of the lid. Pass the cable through the hole in the back of the case, then close the lid.
 
-The switches are connected using two XH-JST 3-pin cables. Connect the first switch to `SWITCH 1 ON-ON` and the second switch to `SWITCH 2 ON-ON` on the breakout board.
+The switches are connected using two JST XH 3-pin cables. Connect the first switch to `SWITCH 1 ON-ON` and the second switch to `SWITCH 2 ON-ON` on the breakout board.
 
 {{< screenshot image="toggle-switch-connections.png" title="Photo of a prototype board with the two toggle switch connections highlighted." >}}
 
@@ -159,7 +159,7 @@ The switches are connected using two XH-JST 3-pin cables. Connect the first swit
 
 Assemble the encoder into the case using M3 screws to attach the PCB to the back of the lid. Pass the cable through the hole in the back of the case, then close the lid.
 
-The encoder is connected using one XH-JST 4-pin cable. Connect the encoder PCB `INNER SHAFT` connector to `Encoder 1` on the breakout board.
+The encoder is connected using one JST XH 4-pin cable. Connect the encoder PCB `INNER SHAFT` connector to `Encoder 1` on the breakout board.
 
 {{< screenshot image="encoder-connections.png" title="Photo of a prototype board with the encoder connection highlighted." >}}
 


### PR DESCRIPTION
Fixes #345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guides to direct users to the GitHub repository for all 3D-printed enclosure files.
  * Introduced a single 3MF file containing all parts arranged for easy printing.
  * Clarified that individual STL files are still available for separate part printing.
  * Removed the previous explicit list of individual STL file links from the documentation.
  * Standardized wiring component terminology to "JST XH" across all workshops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->