### PR TITLE
Remove TLC5940 as it is not compatible

### DIFF
--- a/content/devices/output-shift-register/_index.md
+++ b/content/devices/output-shift-register/_index.md
@@ -49,7 +49,6 @@ There are many chips that function as an output shift register, including many d
 - TLC5927
 - TLC5928
 - TLC59283
-- TLC5940
 
 ## Additional resources
 


### PR DESCRIPTION
Looks like TLC5940 is more fancy that we can handle, so removing it from the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed "TLC5940" from the list of chips in the "Other options" section for output shift registers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->