### PR TITLE
PMDG aircraft: Include 2020 and 2024 file paths

### DIFF
--- a/content/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/index.md
+++ b/content/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/index.md
@@ -32,12 +32,17 @@ The additional steps for PMDG aircraft happen automatically on first run in Mobi
 
 If the aircraft fails to work, enable the data communication manually by editing the file `737_Options.ini / 777_Options.ini`, located in the 737/777 persistent storage folder.
 
-- For Microsoft Store distribution, it is located at
-  - MSFS 2020: `%LOCALAPPDATA%\Packages\Microsoft.FlightSimulator_8wekyb3d8bbwe\LocalState\packages\pmdg-aircraft-<version>\work\`.
-  - MSFS 2024: `%LOCALAPPDATA%\Packages\Microsoft.Limitless_8wekyb3d8bbwe\LocalState\WASM\MSFS2024\pmdg-aircraft-<version>\work\`.
-- For Steam distribution, it is located at
-  - MSFS 2020: `%APPDATA%\Microsoft Flight Simulator\Packages\pmdg-aircraft-<version>\work\`.
-  - MSFS 2024: `%APPDATA%\Microsoft Flight Simulator 2024\WASM\MSFS2024\pmdg-aircraft-<version>\work\`.
+- For Microsoft Store distribution, it is located at:
+  - MSFS 2020: `%LOCALAPPDATA%\Packages\Microsoft.FlightSimulator_8wekyb3d8bbwe\LocalState\packages\pmdg-aircraft-<type>\work\`.
+  - MSFS 2024: `%LOCALAPPDATA%\Packages\Microsoft.Limitless_8wekyb3d8bbwe\LocalState\WASM\MSFS2024\pmdg-aircraft-<type>\work\`.
+- For Steam distribution, it is located at:
+  - MSFS 2020: `%APPDATA%\Microsoft Flight Simulator\Packages\pmdg-aircraft-<type>\work\`.
+  - MSFS 2024: `%APPDATA%\Microsoft Flight Simulator 2024\WASM\MSFS2024\pmdg-aircraft-<type>\work\`.
+
+`<type>` will refer to the aircraft designator. For example:
+
+- 738
+- 77w
 
 The following lines need to be added to the bottom of the file:
 


### PR DESCRIPTION
Includes the file paths for PMDG's Options.ini on MSFS 2024 which uses a slightly different folder convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated PMDG aircraft path instructions to be version-aware, with separate guidance for MSFS 2020 and MSFS 2024 on Microsoft Store and Steam.
  - Replaced fixed, generic folder names with a type-based placeholder for aircraft designators (examples included).
  - Removed obsolete 777-specific folder note.
  - Added instructions and a sample configuration snippet to enable CDU broadcast support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->