### PR TITLE
Add example for observer CDU in PMDG 777

### DIFF
--- a/content/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/index.md
+++ b/content/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/index.md
@@ -44,7 +44,7 @@ If the aircraft fails to work, enable the data communication manually by editing
 - 738
 - 77w
 
-For any aircraft type featuring a maximum of 2 CDUs, the following lines need to be added to the bottom of the file:
+For any aircraft type featuring up to 2 CDUs, the following lines need to be added to the bottom of the file:
 
 ```ini
 [SDK]


### PR DESCRIPTION
I forgot about this in yesterday's update. This adds an example on how to enable the observer CDU in PMDG products that support 3 CDU devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CDU broadcast setup to be conditional on CDU count, covering both 2‑CDU and 3‑CDU scenarios.
  * Added explicit guidance for aircraft with 3 CDUs (e.g., 777) and an example configuration for that case.
  * Refined wording to distinguish steps for aircraft with up to 2 CDUs versus those with 3.
  * Preserved the existing 2‑CDU example for continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->