### PR TITLE
ADC voltage notice for 3.3V microcontrollers

### DIFF
--- a/content/boards/recommended/raspberry-pi-pico/index.md
+++ b/content/boards/recommended/raspberry-pi-pico/index.md
@@ -26,8 +26,8 @@ The Raspberry Pi Pico 1 is a compact board with a moderate number of IO pins. It
 > The Raspberry Pi Pico 1 uses 3.3V for its signals. This has the following implications:
 >
 > - Certain output devices, including the MAX7219 7-segment LED driver chip and all LCDs, require 5V digital signals. If you plan to use those devices with the Pico, you will need to add a level shifter to your build.
-> - The inputs are not designed to handle 5V signal levels. To minimize the risk of damage to the microcontroller, it is recommended to run devices like input shift registers on a 3.3V power supply or use level shifters.
-> - Analog inputs expect a voltage in the range from 0V - 3.3V. Therefore, the positive end of a potentiometer should be connected to 3.3V, not 5V, to ensure reliability and accuracy.
+> - IO pins are not 5V-tolerant. To minimize the risk of damage to the microcontroller, run devices like input shift registers on a 3.3V power supply or use level shifters.
+> - Analog inputs expect a voltage in the range from 0V--3.3V. Therefore, the positive end of a potentiometer should be connected to 3.3V, not 5V, to ensure reliability and accuracy.
 
 | Device                                                   | Limit | Notes                                                                                                                                    |
 | -------------------------------------------------------- | :---: | ---------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/boards/recommended/raspberry-pi-pico/index.md
+++ b/content/boards/recommended/raspberry-pi-pico/index.md
@@ -23,7 +23,11 @@ The Raspberry Pi Pico 1 is a compact board with a moderate number of IO pins. It
 - 3 analog inputs (can be used as digital IO pins).
 
 > [!WARNING]
-> The Raspberry Pi Pico 1 uses 3.3V for its digital signals. Certain output devices, including the MAX7219 7-segment LED driver chip and all LCDs, require 5V digital signals. If you plan to use those devices with the Pico, you will need to add a level shifter to your build.
+> The Raspberry Pi Pico 1 uses 3.3V for its signals. This has the following implications:
+>
+> - Certain output devices, including the MAX7219 7-segment LED driver chip and all LCDs, require 5V digital signals. If you plan to use those devices with the Pico, you will need to add a level shifter to your build.
+> - The inputs are not designed to handle 5V signal levels. To minimize the risk of damage to the microcontroller, it is recommended to run devices like input shift registers on a 3.3V power supply or use level shifters.
+> - Analog inputs expect a voltage in the range from 0V - 3.3V. Therefore, the positive end of a potentiometer should be connected to 3.3V, not 5V, to ensure reliability and accuracy.
 
 | Device                                                   | Limit | Notes                                                                                                                                    |
 | -------------------------------------------------------- | :---: | ---------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/devices/input-shift-register/wiring/index.md
+++ b/content/devices/input-shift-register/wiring/index.md
@@ -37,4 +37,4 @@ MobiFlight supports up to four 74HC165 chips connected in series. When wiring th
 {{< /tabs >}}
 
 > [!TIP]
-> For 3.3V microcontrollers like the [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico/), consider powering the shift registers from 3.3V instead of 5V.
+> For 3.3V microcontrollers like the [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico/), the shift register should be powered from +3.3V instead of +5V unless a level shifter is used.

--- a/content/devices/input-shift-register/wiring/index.md
+++ b/content/devices/input-shift-register/wiring/index.md
@@ -22,6 +22,7 @@ The following components are required to wire buttons to an input shift register
 The 10kΩ resistors are required on every input pin, even if you aren't attaching a button to that pin, to avoid false input events.
 
 {{< schematic image="single-chip.svg" download="single-chip.pdf" title="Schematic for wiring a single 74HC165 chip." >}}
+
 {{< /tab >}}
 
 {{< tab >}}
@@ -30,6 +31,10 @@ MobiFlight supports up to four 74HC165 chips connected in series. When wiring th
 {{< schematic image="multiple-chips.svg" download="multiple-chips.pdf" title="Schematic for wiring four 74HC165 chips in series." >}}
 
 (Buttons and pull-up resistors omitted for clarity)
+
 {{< /tab >}}
 
 {{< /tabs >}}
+
+> [!TIP]
+> For 3.3V microcontrollers like the [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico/), consider powering the shift registers from 3.3V instead of 5V.

--- a/content/devices/multiplexer/wiring/index.md
+++ b/content/devices/multiplexer/wiring/index.md
@@ -21,4 +21,4 @@ The +5V power can come directly from the connected board. When using the chip di
 > [!TIP]
 > When connecting additional multiplexers to the same board, they must share the **S0--S3** pins. Each multiplexer must use a dedicated **SIG** line.
 >
-> In electrically noisy environments, a pull-up resistor can be connected between the microcontroller's supply voltage and **SIG** to increase signal reliability. Use a 10kΩ resistor to **+5V** with 5V data signals, and a 1--5kΩ resistor to **+3V3** with 3.3V data signals.
+> In electrically noisy environments, a pull-up resistor can be connected between the microcontroller's supply voltage and **SIG** to increase signal reliability. Use a 10kΩ resistor to **+5V** with 5V data signals, and a 1--5kΩ resistor to **+3.3V** with 3.3V data signals.

--- a/content/devices/multiplexer/wiring/index.md
+++ b/content/devices/multiplexer/wiring/index.md
@@ -21,4 +21,4 @@ The +5V power can come directly from the connected board. When using the chip di
 > [!TIP]
 > When connecting additional multiplexers to the same board, they must share the **S0--S3** pins. Each multiplexer must use a dedicated **SIG** line.
 >
-> In electrically noisy environments, a pull-up resistor can be connected between **+5V** and **SIG** to increase signal reliability. Use a 10kΩ resistor with +5V data signals, and a 1--5kΩ resistor with +3.3V data signals.
+> In electrically noisy environments, a pull-up resistor can be connected between the microcontroller's supply voltage and **SIG** to increase signal reliability. Use a 10kΩ resistor to **+5V** with 5V data signals, and a 1--5kΩ resistor to **+3V3** with 3.3V data signals.

--- a/content/devices/potentiometer/wiring/index.md
+++ b/content/devices/potentiometer/wiring/index.md
@@ -1,14 +1,15 @@
 ---
 title: Wiring
 description: Step-by-step instructions for wiring potentiometers.
+ogimage: card-images/devices/potentiometer.png
 weight: 10
 prev: /devices/potentiometer/
 ---
 
-Potentiometers have three pins. The outer two pins are connected to +5V and GND respectively. The middle pin is connected to an analog input on the board.
+Potentiometers have three pins. The outer two pins are connected to microcontroller's supply voltage (usually +5V, but sometimes +3.3V) and GND respectively. The middle pin is connected to an analog input on the board.
 
 > [!WARNING]
-> On 3.3V microcontroller boards such as the [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico/), connect the +5V end to +3.3V instead to be able to use the full range of the potentiometer and to minimize the risk of damage to the microcontroller.
+> On 3.3V microcontroller boards such as the [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico/), connect the potentiometer pin that would normally go to +5V to +3.3V instead. This makes it possible to use the full range of the potentiometer and minimizes the risk of damage to the microcontroller.
 
 {{< schematic image="potentiometer.svg" download="potentiometer.pdf" title="Schematic for wiring a potentiometer." >}}
 

--- a/content/devices/potentiometer/wiring/index.md
+++ b/content/devices/potentiometer/wiring/index.md
@@ -7,7 +7,10 @@ prev: /devices/potentiometer/
 
 Potentiometers have three pins. The outer two pins are connected to +5V and GND respectively. The middle pin is connected to an analog input on the board.
 
-> [!TIP]
-> See the [boards page](/boards/) for pinout diagrams with the available analog pins on each supported board.
+> [!WARNING]
+> On 3.3V microcontroller boards such as the [Raspberry Pi Pico 1](/boards/recommended/raspberry-pi-pico/), connect the +5V end to +3.3V instead to be able to use the full range of the potentiometer and to minimize the risk of damage to the microcontroller.
 
 {{< schematic image="potentiometer.svg" download="potentiometer.pdf" title="Schematic for wiring a potentiometer." >}}
+
+> [!TIP]
+> See the [boards page](/boards/) for pinout diagrams with the available analog pins on each supported board.


### PR DESCRIPTION
Fixes #354 

Also adds a similar notice to input shift registers, which can also feed 5V into an input that is not rated for 5V tolerance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Raspberry Pi Pico guidance expanded: clearer multi-point warning about 3.3V I/O, level‑shifters, and analog input wiring.
  * Shift-register wiring: minor formatting and readability tweaks; added tip to prefer +3.3V supply when using 3.3V microcontrollers.
  * Potentiometer wiring: upgraded tip to a warning for 3.3V boards; clarified pin/supply descriptions and reordered admonitions.
  * Multiplexer wiring: clarified pull‑up reference to the microcontroller supply and clarified voltage/resistor guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->