### PR TITLE
Add new Winwing devices

### DIFF
--- a/content/game-controllers/winwing/_index.md
+++ b/content/game-controllers/winwing/_index.md
@@ -10,7 +10,10 @@ weight: 50
 <!-- Markdownlint doesn't know about consecutive GitHub tip blocks -->
 <!-- markdownlint-disable MD028-->
 
-MobiFlight supports the WINWING FCU, EFIS, MCDU, PAP 3, PFP 3N, PFP 4, PFP 7, 3N PDC, and 3M PDC.
+MobiFlight supports the WINWING FCU, EFIS, MCDU, PAP 3, PFP 3N, PFP 4, PFP 7, 3N PDC, 3M PDC, Airbus throttle, and Airbus sidestick.
+
+> [!NOTE]
+> The trim LCD display on the Airbus throttle is not supported.
 
 The WINWING CDU requires the MobiFlight 11 beta, and its inputs work like any other [game controller input](/game-controllers/configuring-input/). The display portion of the CDU with MobiFlight requires additional configuration, and is only supported with specific aircraft. See the [WINWING CDU documentation](/game-controllers/winwing/winwing-cdu/) for more information.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WINWING controllers page to include 3N PDC, 3M PDC, Airbus throttle, and Airbus sidestick as supported devices, improving device coverage and clarity for users.
  * Added a prominent note specifying that the Airbus throttle trim LCD display is not supported, helping set accurate expectations for functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->