### PR TITLE
Add prosim aircraft

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -98,6 +98,7 @@
     "pinouts",
     "plainify",
     "PMDG",
+    "Prosim",
     "RCLK",
     "REXT",
     "Saitek",

--- a/content/game-controllers/winwing/winwing-cdu/_index.md
+++ b/content/game-controllers/winwing/winwing-cdu/_index.md
@@ -21,6 +21,8 @@ MobiFlight supports WINWING CDU devices with the MobiFlight 11 beta builds. All 
 | MSFS     | PMDG 737           | CPT or FO or CPT+FO                      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
 | MSFS     | PMDG 777           | CPT or FO or CPT+FO                      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
 | MSFS     | TFDi MD-11         | CPT or FO or CPT+FO                      |                                                                                                           |
+| Prosim   | A320               | CPT or FO or CPT+FO                      |                                                                                                           |
+| Prosim   | 737                | CPT or FO or CPT+FO                      |                                                                                                           |
 | X-Plane  | FlightFactor 757   | CPT or FO or CPT+FO                      |                                                                                                           |
 | X-Plane  | FlightFactor 767   | CPT or FO or CPT+FO                      |                                                                                                           |
 | X-Plane  | FlightFactor 777v2 | CPT or FO or Observer or CPT+FO+Observer |                                                                                                           |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded WINWING CDU compatibility table with support for Prosim A320 and Prosim 737 aircraft configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->