### PR TITLE
Add missing PWM tip

### DIFF
--- a/content/devices/output-shift-register/wiring/index.md
+++ b/content/devices/output-shift-register/wiring/index.md
@@ -28,6 +28,9 @@ Pay close attention to the orientation of the LEDs: the anode (long leg) should 
 > Using a DM13A or other similar LED driver chip is a better choice than using the 74HC595 for driving LEDs.
 
 > [!TIP]
+> Connecting pin 21, {{% overline %}}EN{{% /overline %}}, to a PWM pin on a board enables brightness control of the LEDs as a group from MobiFlight.
+
+> [!TIP]
 > To daisy-chain 74HC595 chips, connect the `QH'` pin (9) from one chip to the `SER` pin (14) of the next chip. All other control signals, including `SRCLK` (11) and `RCLK` (12), must be shared across all chained shift registers.
 
 {{< /tab >}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation sections on LED brightness control for shift registers. These sections explain how to wire the EN (enable) pin to a PWM source to achieve dynamic brightness adjustment. Comprehensive guidance provided for multiple chip type configurations, giving users expanded brightness management options and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->