### PR TITLE
mention 360 degree servos are not suitable for gauges

### DIFF
--- a/content/devices/servo/_index.md
+++ b/content/devices/servo/_index.md
@@ -16,3 +16,8 @@ For information on how many servos can be connected to a board, see the [boards]
 ## Popular options
 
 The most widely used servo with MobiFlight is often referred to as a "[9g micro servo](https://www.amazon.com/s?k=micro+servo+motor)" and is sold in multipacks.
+
+> [!WARNING]
+> Some servos are described as `360 degree servos`. These servos have a mid-point position when provided a value of 512, move left when provided a value less than 512, and move right when provided a value greater than 512. Since they rotate continuously when given a value, they are not suitable for making gauges like altitude indicators.
+>
+> For gauges that need full 360 degree rotation use a [stepper motor](/devices/stepper-motor) instead.


### PR DESCRIPTION
Fixes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on servo selection for gauge applications, including a warning about continuous-rotation servos and recommendations for stepper motor alternatives.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->