### PR TITLE
Fix broken link on joystick axis page

### DIFF
--- a/content/game-controllers/configuring-input/index.md
+++ b/content/game-controllers/configuring-input/index.md
@@ -17,7 +17,7 @@ When selecting the **Module** and **Device**, select the appropriate game contro
 
 ## Slider and axis inputs
 
-These inputs, including throttle levers and yokes, are configured in MobiFlight using [the potentiometer configuration process](/devices/potentiometer/configuring-input).
+These inputs, including throttle levers and yokes, are configured in MobiFlight using [the potentiometer configuration process](/devices/potentiometer/configuring-device).
 
 When selecting the **Module** and **Device**, select the appropriate game controller and switch. Alternatively, press the **Scan for input** button and move the input to automatically detect and select the axis.
 


### PR DESCRIPTION
Fixes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated potentiometer configuration reference in game controller input documentation to reflect the correct navigation path for device configuration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->