### PR TITLE
Add new WINWING CDU aircraft

### DIFF
--- a/content/game-controllers/winwing/winwing-cdu/_index.md
+++ b/content/game-controllers/winwing/winwing-cdu/_index.md
@@ -20,6 +20,7 @@ MobiFlight supports WINWING CDU devices with the MobiFlight 11 beta builds. All 
 | MSFS     | FSLabs A321        | CPT                                      |                                                                                                           |
 | MSFS     | Headwind A339x     | CPT or FO                                | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
 | MSFS     | iFly 737           | CPT or FO or CPT+FO                      | CPT+FO untested so far                                                                                    |
+| MSFS     | iniBuilds A340     | CPT or FO                                |                                                                                                           |
 | MSFS     | Maddog X           | CPT or FO or CPT+FO                      |                                                                                                           |
 | MSFS     | PMDG 737           | CPT or FO or CPT+FO                      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |
 | MSFS     | PMDG 777           | CPT or FO or CPT+FO                      | [Requires additional configuration](/game-controllers/winwing/winwing-cdu/detailed-aircraft-information/) |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated WINWING CDU compatibility table: added iniBuilds A340 (supports Captain or First Officer), Rotate MD-11 (supports Captain, First Officer, Observer, and combined multi-crew setups), and Rotate MD-80 (supports Captain).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->