### PR TITLE
Remove AGP clock reference

### DIFF
--- a/content/game-controllers/winwing/_index.md
+++ b/content/game-controllers/winwing/_index.md
@@ -12,9 +12,6 @@ weight: 50
 
 MobiFlight supports the WINWING AGP, ECAM, EFIS, FCU, MCDU, PAP 3, PFP 3N, PFP 4, PFP 7, 3N PDC, 3M PDC, Airbus throttle, and Airbus sidestick.
 
-> [!NOTE]
-> The clock on the AGP is not supported.
-
 The WINWING CDU requires the MobiFlight 11 beta, and its inputs work like any other [game controller input](/game-controllers/configuring-input/). The display portion of the CDU with MobiFlight requires additional configuration, and is only supported with specific aircraft. See the [WINWING CDU documentation](/game-controllers/winwing/winwing-cdu/) for more information.
 
 WINWING devices are automatically shown in the [input](/game-controllers/configuring-input/) and [output](/game-controllers/configuring-output/) configuration dialogs. They will not appear in the **Modules** tab of the **Settings** dialog as they are not [boards](/boards/).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       prettier:
-        specifier: ^3.8.0
+        specifier: ^3.4.2
         version: 3.8.0
       prettier-plugin-go-template:
         specifier: ^0.0.15


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed documentation note regarding AGP clock support limitation from game controller documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->