### PR TITLE
WINCTRL CDU Reverse video support

### DIFF
--- a/content/game-controllers/winctrl/winctrl-cdu/dev-instructions/index.md
+++ b/content/game-controllers/winctrl/winctrl-cdu/dev-instructions/index.md
@@ -27,10 +27,11 @@ ws://localhost:8320/winwing/cdu-observer
 
 JSON structure with a list of 336 elements in the Data section for the 336 possible characters on the CDU.
 
-- Each list element is a triplet.
+- Each list element is a quadruplet.
   1. The character to be shown as UTF-8 string.
   2. The color as UTF-8 string.
   3. The size as a number (0 large, 1 small).
+  4. The style denoting reverse video/inverted text (0 normal, 1 inverse) (Optional: defaults to 0).
 - For the empty character "SPACE", also an empty list element [] can be used, instead of [" ", "w", 0].
 
 ## Color identifiers
@@ -43,7 +44,7 @@ JSON structure with a list of 336 elements in the Data section for the 336 possi
 "m" // magenta
 "r" // red
 "y" // yellow
-"o" // brown
+"o" // blue
 "e" // grey
 "k" // khaki
 ```


### PR DESCRIPTION
Adds documentation for the new backwards compatible schema which supports reverse-video functionality for WINWING CDUs

This also corrects an incorrect colour. `o` represents blue rather than brown

Dependency: https://github.com/MobiFlight/MobiFlight-Connector/pull/2742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer documentation to reflect enhancements to the data structure, now supporting an optional style parameter that enables both normal and inverse display modes for improved flexibility.
  * Revised color identifier mapping to provide better visual consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->