### PR TITLE
Update Akai MPK mini play link to new version

### DIFF
--- a/content/midi-devices/_index.md
+++ b/content/midi-devices/_index.md
@@ -13,7 +13,7 @@ MobiFlight supports several popular MIDI devices. While no drivers are required,
 ## Supported devices
 
 - [Akai MPD218](https://www.akaipro.com/mpd218)
-- [Akai MPK mini play](https://www.akaipro.com/mpk-mini-play)
+- [Akai MPK mini play](https://www.akaipro.com/mpk-mini-play-mk3/)
 - [Behringer X-TOUCH MINI](https://www.behringer.com/behringer/product?modelCode=0808-AAF)
 - [Intech EF44](https://intech.studio/shop/ef44)
 - [KORG nanoKONTROL2](https://www.korg.com/us/products/computergear/nanokontrol2/)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the supported MIDI devices documentation with the correct product link for the Akai MPK mini play device, referencing the current version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->