### PR TITLE
Add WingFlex to list of conflicting applications

### DIFF
--- a/content/guides/solving-flashing-errors/_index.md
+++ b/content/guides/solving-flashing-errors/_index.md
@@ -32,6 +32,7 @@ Common apps causing this issue include:
 - CURA
 - Joystick configuration software
 - Sim Racing Studio
+- WingFlex
 
 Close any of these applications that may be running. A PC reboot may be necessary to ensure the conflicting applications are fully closed. Then, try flashing the board again.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated flashing troubleshooting guide to include WingFlex as an application that may hold the board's COM port, requiring it to be closed before attempting to flash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->