### PR TITLE
Add compatible-only

### DIFF
--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -17,6 +17,7 @@ cascade:
 {{< card link="/guides/flashing-ambiguous-boards/" title="Flashing ambiguous boards" icon="cpu-chip" >}}
 {{< card link="/guides/soldering/" title="Making good solder connections" icon="cpu-chip" >}}
 {{< card link="/guides/modifying-values-with-ncalc/" title="Modifying values with NCalc" icon="calculator" >}}
+{{< card link="/guides/compatible-only/" title="Solving compatible-only boards" icon="cpu-chip" >}}
 {{< card link="/guides/solving-flashing-errors/" title="Solving flashing errors" icon="cpu-chip" >}}
 {{< card link="https://github.com/MobiFlight/MobiFlight-Connector/wiki" title="Legacy guides" icon="information" >}}
 {{< card link="/guides/workshops" title="Workshop walkthroughs" icon="cog" >}}

--- a/content/guides/compatible-only/_index.md
+++ b/content/guides/compatible-only/_index.md
@@ -1,0 +1,36 @@
+---
+title: Boards only show as compatible
+description: Step-by-step guide to solving boards that only appear as compatible in MobiFlight.
+---
+
+Sometimes boards that were previously flashed with MobiFlight will only show as **Compatible** in the MobiFlight modules dialog. To resolve this, try the following.
+
+{{% steps %}}
+
+### Ensure other apps aren't using the COM port
+
+Many other applications open the COM port to connected boards automatically, preventing MobiFlight from communicating with the board. Common apps causing this issue include:
+
+- Arduino IDE
+- CURA
+- Joystick configuration software
+- Sim Racing Studio
+- WingFlex
+
+Close any of these applications that may be running. A PC reboot may be necessary to ensure the conflicting applications are fully closed. Then, try running MobiFlight again.
+
+If it still fails, try moving the board to a different COM port, or uninstall it using Windows Device Manager then plug it in again.
+
+### Try removing all connected hats and devices removed
+
+Low-quality Arduino screw terminal hats may interfere with board detection. Incorrectly connected devices can also cause shorts, preventing the board from being used. Try removing all hats and disconnecting all devices from the board, then run MobiFlight again.
+
+### Collect logs for additional support
+
+If the previous steps do not resolve the flashing error, start a thread in the [#MobiFlight](https://discord.com/channels/608690978081210392/1028767888242376794) support channel in [Discord](https://discord.gg/yUaBqMbz). Include the following information:
+
+- The type of board being flashed.
+- A photo of the specific board, with the chips near the USB connector clearly visible.
+- The complete logs collected by following the [sharing logs guide](/guides/sharing-logs/). Set the log level to **Debug** when enabling logging.
+
+{{% /steps %}}

--- a/content/troubleshooting/_index.md
+++ b/content/troubleshooting/_index.md
@@ -8,6 +8,13 @@ cascade:
   type: docs
 ---
 
+## Boards
+
+{{< cards >}}
+{{< card link="/guides/compatible-only/" title="Solving compatible-only boards" icon="cpu-chip" >}}
+{{< card link="/guides/solving-flashing-errors/" title="Solving flashing errors" icon="cpu-chip" >}}
+{{< /cards >}}
+
 ## Devices
 
 {{< cards >}}
@@ -27,7 +34,6 @@ cascade:
 
 {{< cards >}}
 {{< card link="/guides/sharing-logs/" title="Sharing logs" icon="clipboard-document-list" >}}
-{{< card link="/guides/solving-flashing-errors/" title="Solving flashing errors" icon="cpu-chip" >}}
 {{< card link="/guides/taking-screenshots/" title="Taking screenshots" icon="camera" >}}
 {{< card link="/guides/wasm-module/" title="WASM module installation" icon="download" >}}
 {{< /cards >}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for boards appearing as "Compatible-only" in MobiFlight, including diagnostic steps for COM port conflicts, device re-detection, and hardware interference.
  * Reorganized troubleshooting documentation with a dedicated "Boards" section for board-specific troubleshooting resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->