### PR TITLE
Clarify how to use existing profiles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -99,6 +99,7 @@
     "pinouts",
     "plainify",
     "PMDG",
+    "premade",
     "Prepar3D",
     "Prosim",
     "RCLK",

--- a/content/game-controllers/winctrl/premade-profiles/index.md
+++ b/content/game-controllers/winctrl/premade-profiles/index.md
@@ -58,6 +58,3 @@ The project will open and display the input and output configurations.
 
 {{< screenshot image="project-details.png" title="Screenshot of an open MobiFlight project." >}}
 {{% /steps %}}
-
-> [!TIP]
-> If MobiFlight is unable to automatically map connected WinCtrl devices to the ones used in the profile, use the **[Controller Bindings](/features/controller-bindings/)** dialog to manually map the devices.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated profile file compatibility to support both .mcc and .mfproj formats.
  * Clarified manual-mapping guidance: removed the outdated tip and added a new tip directing users to the Controller Bindings dialog when automatic device mapping fails (legacy orphaned-serials dialog no longer used).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->