### PR TITLE
Remove references to Mobiflight 11 beta

### DIFF
--- a/content/game-controllers/winctrl/_index.md
+++ b/content/game-controllers/winctrl/_index.md
@@ -13,7 +13,7 @@ weight: 50
 
 MobiFlight supports the WinCtrl AGP, ECAM, EFIS, FCU, MCDU, PAP 3, PFP 3N, PFP 4, PFP 7, 3N PDC, 3M PDC, PTO 2, Airbus throttle, and Airbus sidestick.
 
-The WinCtrl CDU requires the MobiFlight 11 beta, and its inputs work like any other [game controller input](/game-controllers/configuring-input/). The display portion of the CDU with MobiFlight requires additional configuration, and is only supported with specific aircraft. See the [WinCtrl CDU documentation](/game-controllers/winctrl/winctrl-cdu/) for more information.
+The WinCtrl CDU inputs work like any other [game controller input](/game-controllers/configuring-input/). The display portion of the CDU with MobiFlight requires additional configuration, and is only supported with specific aircraft. See the [WinCtrl CDU documentation](/game-controllers/winctrl/winctrl-cdu/) for more information.
 
 WinCtrl devices are automatically shown in the [input](/game-controllers/configuring-input/) and [output](/game-controllers/configuring-output/) configuration dialogs. They will not appear in the **Modules** tab of the **Settings** dialog as they are not [boards](/boards/).
 

--- a/content/game-controllers/winctrl/winctrl-cdu/_index.md
+++ b/content/game-controllers/winctrl/winctrl-cdu/_index.md
@@ -14,7 +14,7 @@ weight: 30
 > [!WARNING]
 > MobiFlight and SimAppPro cannot be used with a CDU at the same time. If using MobiFlight with the CDU, SimAppPro must be completely exited.
 
-MobiFlight supports WinCtrl CDU devices with the MobiFlight 11 beta builds. All buttons are automatically available as [game controller inputs](/game-controllers/configuring-input/); however, using the display for output requires additional setup and is only supported with the following aircraft:
+MobiFlight supports WinCtrl CDU devices. All buttons are automatically available as [game controller inputs](/game-controllers/configuring-input/); however, using the display for output requires additional setup and is only supported with the following aircraft:
 
 | Platform   | Aircraft                | Supported configurations                 | Comment                                                                                                   |
 | ---------- | ----------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Fixes #478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WinCtrl CDU compatibility information to clarify broader MobiFlight support for WinCtrl CDU devices, removing previous version restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->