### PR TITLE
Add WingFlex FCU

### DIFF
--- a/content/game-controllers/_index.md
+++ b/content/game-controllers/_index.md
@@ -32,6 +32,7 @@ For popular devices, MobiFlight displays friendly names during input and output 
 | WinCtrl PFP 4                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
 | WinCtrl PFP 7                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
 | WinCtrl PTO 2                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
+| WingFlex FCU                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
 
 For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/).
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WingFlex FCU to the officially supported game controllers list. This device supports both input and output operations, providing users with a new controller option. The supported devices documentation has been updated accordingly, enabling developers to seamlessly integrate the WingFlex FCU into their applications for enhanced gaming experiences and better interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->