### PR TITLE
Add WinCtrl TCAS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -117,6 +117,7 @@
     "streamdeck",
     "svgomg",
     "Tayda",
+    "TCAS",
     "Thrustmaster",
     "trackaudio",
     "Unported",

--- a/content/game-controllers/_index.md
+++ b/content/game-controllers/_index.md
@@ -32,6 +32,7 @@ For popular devices, MobiFlight displays friendly names during input and output 
 | WinCtrl PFP 4                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
 | WinCtrl PFP 7                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
 | WinCtrl PTO 2                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
+| WinCtrl TCAS                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
 | WingFlex FCU                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                   |
 
 For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/).

--- a/content/game-controllers/winctrl/_index.md
+++ b/content/game-controllers/winctrl/_index.md
@@ -11,7 +11,7 @@ weight: 50
 <!-- Markdownlint doesn't know about consecutive GitHub tip blocks -->
 <!-- markdownlint-disable MD028-->
 
-MobiFlight supports the WinCtrl AGP, ECAM, EFIS, FCU, MCDU, PAP 3, PFP 3N, PFP 4, PFP 7, 3N PDC, 3M PDC, PTO 2, Airbus throttle, and Airbus sidestick.
+MobiFlight supports the WinCtrl AGP, ECAM, EFIS, FCU, MCDU, PAP 3, PFP 3N, PFP 4, PFP 7, 3N PDC, 3M PDC, PTO 2, TCAS, Airbus throttle, and Airbus sidestick.
 
 The WinCtrl CDU inputs work like any other [game controller input](/game-controllers/configuring-input/). The display portion of the CDU with MobiFlight requires additional configuration, and is only supported with specific aircraft. See the [WinCtrl CDU documentation](/game-controllers/winctrl/winctrl-cdu/) for more information.
 


### PR DESCRIPTION
Fixes #484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WinCtrl TCAS to the supported game controllers list, confirming compatibility with both inputs and outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->