### PR TITLE
Remove configurations from winctrl CDU table

### DIFF
--- a/content/game-controllers/winctrl/winctrl-cdu/supported-aircraft.json
+++ b/content/game-controllers/winctrl/winctrl-cdu/supported-aircraft.json
@@ -3,157 +3,131 @@
     {
       "platform": "MSFS",
       "aircraft": "Aerosoft CRJ",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "MSFS",
       "aircraft": "Fenix A3xx",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "MSFS",
       "aircraft": "FlyByWire A32NX",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": "[Requires additional configuration](/game-controllers/winctrl/winctrl-cdu/detailed-aircraft-information/)"
     },
     {
       "platform": "MSFS",
       "aircraft": "FSLabs A321",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "MSFS",
       "aircraft": "Headwind A339x",
-      "configurations": "CPT or FO",
       "comment": "[Requires additional configuration](/game-controllers/winctrl/winctrl-cdu/detailed-aircraft-information/)"
     },
     {
       "platform": "MSFS",
       "aircraft": "iFly 737",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": "CPT+FO untested so far"
     },
     {
       "platform": "MSFS",
       "aircraft": "iniBuilds A340",
-      "configurations": "CPT or FO",
       "comment": ""
     },
     {
       "platform": "MSFS",
       "aircraft": "Maddog X",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "MSFS",
       "aircraft": "PMDG 737",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": "[Requires additional configuration](/game-controllers/winctrl/winctrl-cdu/detailed-aircraft-information/)"
     },
     {
       "platform": "MSFS",
       "aircraft": "PMDG 777",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": "[Requires additional configuration](/game-controllers/winctrl/winctrl-cdu/detailed-aircraft-information/)"
     },
     {
       "platform": "MSFS",
       "aircraft": "TFDi MD-11",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "Prosim",
       "aircraft": "A320",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "Prosim",
       "aircraft": "737",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "FlightFactor 757",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "FlightFactor 767",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "FlightFactor 777v2",
-      "configurations": "CPT or FO or Observer or CPT+FO+Observer",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "Hotstart Challenger 650",
-      "configurations": "CPT or FO or Observer or CPT+FO+Observer",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "LevelUp 737",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "Rotate MD-11",
-      "configurations": "CPT or FO or Observer or CPT+FO+Observer",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "Rotate MD-80",
-      "configurations": "CPT",
-      "comment": ""
+      "comment": "Captain only"
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "ToLiss A319",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "ToLiss A320",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "ToLiss A321",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "ToLiss A330",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "ToLiss A340",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     },
     {
       "platform": "X-Plane 12",
       "aircraft": "Zibo 737",
-      "configurations": "CPT or FO or CPT+FO",
       "comment": ""
     }
   ]

--- a/layouts/shortcodes/winctrl-cdu-aircraft-table.html
+++ b/layouts/shortcodes/winctrl-cdu-aircraft-table.html
@@ -1,25 +1,23 @@
 {{- $jsonFile := .Page.Resources.GetMatch "supported-aircraft.json" -}}
 {{- if $jsonFile -}}
-{{- $data := $jsonFile.Content | unmarshal -}}
-{{- $sorted := sort $data.aircraft "platform" "aircraft" -}}
-<table>
-  <thead>
-    <tr>
-      <th>Platform</th>
-      <th>Aircraft</th>
-      <th>Supported configurations</th>
-      <th>Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{- range $sorted }}
-    <tr>
-      <td>{{ .platform }}</td>
-      <td>{{ .aircraft }}</td>
-      <td>{{ .configurations }}</td>
-      <td>{{ $.Page.RenderString .comment }}</td>
-    </tr>
-    {{- end }}
-  </tbody>
-</table>
+  {{- $data := $jsonFile.Content | unmarshal -}}
+  {{- $sorted := sort $data.aircraft "platform" "aircraft" -}}
+  <table>
+    <thead>
+      <tr>
+        <th>Platform</th>
+        <th>Aircraft</th>
+        <th>Comment</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{- range $sorted }}
+        <tr>
+          <td>{{ .platform }}</td>
+          <td>{{ .aircraft }}</td>
+          <td>{{ $.Page.RenderString .comment }}</td>
+        </tr>
+      {{- end }}
+    </tbody>
+  </table>
 {{- end }}


### PR DESCRIPTION
Fixes #491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the aircraft support data structure and table display—configuration information is now consolidated in comments, and the Supported configurations column has been removed from the aircraft table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neilenns-projects/mobiflight-docs/pull/492)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->