### PR TITLE
Fix app name in command line parameter

### DIFF
--- a/content/features/command-line-parameters/index.md
+++ b/content/features/command-line-parameters/index.md
@@ -13,5 +13,5 @@ MobiFlight supports the following command line parameters:
 To load a specific project and automatically start `Run` mode when the flight simulator is detected, combine the parameters:
 
 ```powershell
-MobiFlight-Connector.exe /cfg "C:\MobiFlight\Cessna 172.mfproj" /autoRun
+MFConnector.exe /cfg "C:\MobiFlight\Cessna 172.mfproj" /autoRun
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line parameter examples to reflect the correct executable name for launching MobiFlight with project configuration and auto-start options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neilenns-projects/mobiflight-docs/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->