### PR TITLE
Add Aerosoft A340-600 Pro

### DIFF
--- a/content/game-controllers/winctrl/winctrl-cdu/supported-aircraft.json
+++ b/content/game-controllers/winctrl/winctrl-cdu/supported-aircraft.json
@@ -165,6 +165,10 @@
       "platform": "X-Plane 12",
       "aircraft": "Leonardo Fly The Maddog 20th Anniversary Edition",
       "comment": ""
+    },
+    {
+      "platform": "MSFS",
+      "aircraft": "Aerosoft A340-600 Pro"
     }
   ]
 }

--- a/content/game-controllers/winctrl/winctrl-cdu/supported-aircraft.json
+++ b/content/game-controllers/winctrl/winctrl-cdu/supported-aircraft.json
@@ -168,7 +168,8 @@
     },
     {
       "platform": "MSFS",
-      "aircraft": "Aerosoft A340-600 Pro"
+      "aircraft": "Aerosoft A340-600 Pro",
+      "comment": "Requires aircraft version v1.0.3 or later and Microsoft Flight Simulator 2024."
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for **MSFS / Aerosoft A340-600 Pro**.
  * Requires **MSFS 2024** and **aircraft version v1.0.3** or later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->