### PR TITLE
Add WinCtrl RMP documentation

### DIFF
--- a/content/game-controllers/_index.md
+++ b/content/game-controllers/_index.md
@@ -32,10 +32,11 @@ For popular devices, MobiFlight displays friendly names during input and output 
 | WinCtrl PFP 4                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WinCtrl PFP 7                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WinCtrl PTO 2                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
+| WinCtrl RMP                                                                                                                       |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WinCtrl TCAS                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex FCU                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 
-For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/).
+For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/). The WinCtrl RMP device provides [specific input and output devices](/game-controllers/winctrl/winctrl-rmp/) when creating profiles.
 
 > [!TIP]
 > Other game controllers may work and show generic names for inputs; however their outputs are not supported. Unlisted WinCtrl devices are not supported.

--- a/content/game-controllers/_index.md
+++ b/content/game-controllers/_index.md
@@ -36,7 +36,7 @@ For popular devices, MobiFlight displays friendly names during input and output 
 | WinCtrl TCAS                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex FCU                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 
-For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/). The WinCtrl RMP device provides [specific input and output devices](/game-controllers/winctrl/winctrl-rmp/) when creating profiles.
+For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/). The WinCtrl RMP displays and LEDs are controlled using [specific output devices](/game-controllers/winctrl/winctrl-rmp/).
 
 > [!TIP]
 > Other game controllers may work and show generic names for inputs; however their outputs are not supported. Unlisted WinCtrl devices are not supported.

--- a/content/game-controllers/winctrl/_index.md
+++ b/content/game-controllers/winctrl/_index.md
@@ -11,9 +11,11 @@ weight: 50
 <!-- Markdownlint doesn't know about consecutive GitHub tip blocks -->
 <!-- markdownlint-disable MD028-->
 
-MobiFlight supports the WinCtrl AGP, ECAM, EFIS, FCU, MCDU, PAP 3, PFP 3N, PFP 4, PFP 7, 3N PDC, 3M PDC, PTO 2, TCAS, Airbus throttle, and Airbus sidestick.
+MobiFlight supports the WinCtrl AGP, ECAM, EFIS, FCU, MCDU, PAP 3, PFP 3N, PFP 4, PFP 7, 3N PDC, 3M PDC, PTO 2, RMP, TCAS, Airbus throttle, and Airbus sidestick.
 
 The WinCtrl CDU inputs work like any other [game controller input](/game-controllers/configuring-input/). The display portion of the CDU with MobiFlight requires additional configuration, and is only supported with specific aircraft. See the [WinCtrl CDU documentation](/game-controllers/winctrl/winctrl-cdu/) for more information.
+
+The WinCtrl RMP displays and LEDs are controlled using [specific output devices](/game-controllers/winctrl/winctrl-rmp/).
 
 WinCtrl devices are automatically shown in the [input](/game-controllers/configuring-input/) and [output](/game-controllers/configuring-output/) configuration dialogs. They will not appear in the **Modules** tab of the **Settings** dialog as they are not [boards](/boards/).
 

--- a/content/game-controllers/winctrl/winctrl-rmp/_index.md
+++ b/content/game-controllers/winctrl/winctrl-rmp/_index.md
@@ -1,0 +1,56 @@
+---
+title: WinCtrl RMP
+description: Instructions on how to use the WinCtrl RMP with MobiFlight.
+weight: 40
+---
+
+The WinCtrl RMP provides several output devices in MobiFlight for use when creating profiles.
+
+## Configuring active and standby value display
+
+Four outputs are provided to control the active and standby displays:
+
+- `Active Value`: The current value for the **ACTIVE** (left) display.
+- `Standby Value`: The current value for the **STBY/CRS** (right) display.
+- `Active Mode`: Determines how the `Active Value` output is displayed.
+- `Standby Mode`: Determines how the `Standby Value` output is displayed.
+
+The supported values for `Active Mode` and `Standby Mode` are:
+
+| Mode | Use                                  | Unit           | Simulator value -> Displayed value           |
+| ---- | ------------------------------------ | -------------- | -------------------------------------------- |
+| 0    | Blank display                        | not applicable | _blank_                                      |
+| 1    | VHF/HF COM, VOR, and ILS frequencies | MHz            | `118.005` -> `118.005`, `113.3` -> `113.300` |
+| 2    | ADF/NDB frequencies                  | KHz            | `347` -> `347.0`, `1750` -> `1750.0`         |
+| 3    | Course (CRS)                         | degrees        | `240` -> `C-240`                             |
+| 4    | VHF3 DATA                            | not applicable | -> `dAtA`                                    |
+
+The value must be output in the appropriate unit for the display based on the set mode. The panel will format the value, but will not do unit conversions.
+
+Changing the `Active Mode` or `Standby Mode` value immediately discards the stored `Active Value` or `Standby Value`. Setting the mode to `0` or `4` takes effect immediately. Setting the mode one of the other options will leave the display unchanged until a new value is provided.
+
+## Controlling display brightness and test mode
+
+The following outputs configure the brightness for the RMP displays:
+
+- `Backlight Percentage`
+- `LCD percentage`
+
+Test mode for the LCD is controlled by the `LCD Test On/Off` output.
+
+## Controlling indicator LEDs
+
+The following outputs control the device indicator LEDs:
+
+- `SEL`
+- `VHF1`
+- `VHF2`
+- `VHF3`
+- `LOAD`
+- `HF1`
+- `HF2`
+- `AM`
+- `NAV`
+- `VORILS`
+- `GLS`
+- `ADF`

--- a/content/game-controllers/winctrl/winctrl-rmp/_index.md
+++ b/content/game-controllers/winctrl/winctrl-rmp/_index.md
@@ -51,6 +51,6 @@ The following outputs control the device indicator LEDs:
 - `HF2`
 - `AM`
 - `NAV`
-- `VORILS`
+- `VOR/ILS`
 - `GLS`
 - `ADF`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive WinCtrl RMP device documentation, including output configuration, display settings (active/standby modes, brightness), LCD test mode, and indicator LED controls.
  * Updated supported devices list to include WinCtrl RMP.
  * Clarified WinCtrl CDU input behavior and display configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->