### PR TITLE
Add tip box to "On Long Release" and "On Hold" action page

### DIFF
--- a/content/devices/button-switch/settings-reference/index.md
+++ b/content/devices/button-switch/settings-reference/index.md
@@ -54,3 +54,8 @@ The **On Long Release** event fires when the button is released after being held
 
 {{< /tab >}}
 {{< /tabs >}}
+
+> [!TIP]
+> To set a button up with separate commands for short and long press, add one command to the **On Release** action and the other to the **On Hold** action. Leave **On Press** blank, and add an **On Long Release** action that has a command with empty code configured.
+>
+> Alternatively, map **On Release** and **On Long Release** to the commands, and leave **On Press** and **On Hold** un-configured.


### PR DESCRIPTION
Fixes #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated settings reference documentation with clearer guidance on configuring separate commands for short vs. long button press actions, including instructions on using different release and hold options and recommendations for which action tabs to leave blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->