### PR TITLE
Add new WinFlex devices & supported CDU aircraft

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,6 +41,7 @@
     "deadzone",
     "discordtimestamp",
     "DPDT",
+    "ECAM",
     "EEPROM",
     "EFIS",
     "Elegoo",

--- a/content/game-controllers/_index.md
+++ b/content/game-controllers/_index.md
@@ -10,9 +10,6 @@ cascade:
   type: docs
 ---
 
-<!-- Markdownlint doesn't understand consecutive GitHub-style info blocks -->
-<!-- markdownlint-disable-file MD028 -->
-
 MobiFlight supports joysticks, yokes, throttle quadrants, and other devices that show in Windows as USB game controllers. No additional drivers are required.
 
 > [!TIP]
@@ -40,14 +37,12 @@ For popular devices, MobiFlight displays friendly names during input and output 
 | WinCtrl PTO 2                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WinCtrl TCAS                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex DAP500                                                                                                                   |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
+| WingFlex ECAM cube                                                                                                                |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex FCU                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex overhead panel                                                                                                           |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex RMP cube                                                                                                                 |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 
 For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/).
-
-> [!TIP]
-> Looking to buy a WingFlex device? Help support MobiFlight by [purchasing through our affiliate link](https://www.wingflex.com?sca_ref=11453765.OPCgaGgkUj), at no additional cost to you.
 
 > [!TIP]
 > Other game controllers may work and show generic names for inputs; however their outputs are not supported. Unlisted WinCtrl devices are not supported.

--- a/content/game-controllers/_index.md
+++ b/content/game-controllers/_index.md
@@ -34,6 +34,7 @@ For popular devices, MobiFlight displays friendly names during input and output 
 | WinCtrl PTO 2                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WinCtrl TCAS                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex FCU                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
+| WingFlex RMP cube                                                                                                                 |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 
 For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/).
 

--- a/content/game-controllers/_index.md
+++ b/content/game-controllers/_index.md
@@ -10,6 +10,9 @@ cascade:
   type: docs
 ---
 
+<!-- Markdownlint doesn't understand consecutive GitHub-style info blocks -->
+<!-- markdownlint-disable-file MD028 -->
+
 MobiFlight supports joysticks, yokes, throttle quadrants, and other devices that show in Windows as USB game controllers. No additional drivers are required.
 
 For popular devices, MobiFlight displays friendly names during input and output configuration. These devices include:
@@ -33,10 +36,15 @@ For popular devices, MobiFlight displays friendly names during input and output 
 | WinCtrl PFP 7                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WinCtrl PTO 2                                                                                                                     |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WinCtrl TCAS                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
+| WingFlex DAP500                                                                                                                   |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex FCU                                                                                                                      |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
+| WingFlex overhead panel                                                                                                           |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 | WingFlex RMP cube                                                                                                                 |                  {{< icon "check" >}}                   |                   {{< icon "check" >}}                    |
 
 For detailed information on using WinCtrl devices with MobiFlight, see the [WinCtrl documentation](/game-controllers/winctrl/). The WinCtrl CDU display is only supported with [select aircraft](/game-controllers/winctrl/winctrl-cdu/).
+
+> [!TIP]
+> Looking to buy a WingFlex device? Help support MobiFlight by [purchasing through our affiliate link](https://www.wingflex.com?sca_ref=11453765.OPCgaGgkUj), at no additional cost to you.
 
 > [!TIP]
 > Other game controllers may work and show generic names for inputs; however their outputs are not supported. Unlisted WinCtrl devices are not supported.

--- a/content/game-controllers/winctrl/winctrl-cdu/supported-aircraft.json
+++ b/content/game-controllers/winctrl/winctrl-cdu/supported-aircraft.json
@@ -165,6 +165,11 @@
       "platform": "X-Plane 12",
       "aircraft": "Leonardo Fly The Maddog 20th Anniversary Edition",
       "comment": ""
+    },
+    {
+      "platform": "MSFS",
+      "aircraft": "Contrail FA50",
+      "comment": ""
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the supported game controllers list to add **WingFlex RMP cube**, marked as supporting both **inputs and outputs**.
  * Expanded the WingFlex section to include additional supported variants: **WingFlex DAP500**, **WingFlex ECAM cube**, and the **WingFlex overhead panel**.
* **Content Updates**
  * Added **Contrail FA50** to the supported aircraft list.
* **Chores**
  * Updated spelling allowlist to recognize **“ECAM.”**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->